### PR TITLE
♻️ 밈 텍스트가 이미지 컨테이너 밖으로 나오지 못하도록 리팩토링

### DIFF
--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
-import { API_DATA, LOCAL_MEME, TEXT_TYPE } from 'types';
+import { API_DATA, LOCAL_MEME, TEXT_BOUNDARY, TEXT_TYPE } from 'types';
 import EditorForm from './EditorForm';
 import EditorImage from './EditorImage';
 import EditorMemeList from './EditorMemeList';
@@ -21,11 +21,22 @@ function Editor({ apiData, currentMeme, setCurrentMeme }: Props) {
     bottom: '',
   });
   const [color, setColor] = useState<string>('#000000');
+  const [textBoundary, setTextBoundary] = useState<TEXT_BOUNDARY | null>(null);
+  const imageRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setText({ top: '', middle: '', bottom: '' });
+    if (currentMeme) {
+      const image = imageRef.current;
+      const rightBoundary = image!.offsetWidth;
+      const bottomBoundary = image!.offsetHeight;
+      const boundary = {
+        right: rightBoundary,
+        bottom: bottomBoundary,
+      };
+      setTextBoundary(boundary);
+    }
   }, [currentMeme]);
-  const imageRef = useRef<HTMLDivElement>(null);
 
   const saveImage = async (num: number) => {
     if (!imageRef.current) {
@@ -51,6 +62,7 @@ function Editor({ apiData, currentMeme, setCurrentMeme }: Props) {
         text={text}
         color={color}
         ref={imageRef}
+        textBoundary={textBoundary}
       />
       <RightBox>
         <EditorMemeList

--- a/components/editor/EditorImage.tsx
+++ b/components/editor/EditorImage.tsx
@@ -6,23 +6,22 @@ import React, {
   useState,
 } from 'react';
 import styled from '@emotion/styled';
-import { API_DATA, LOCAL_MEME, TEXT_TYPE } from 'types';
+import { API_DATA, LOCAL_MEME, TEXT_BOUNDARY, TEXT_TYPE } from 'types';
 import { COLOR, DEVICE } from 'constants/';
 import { ImageText } from './ImageText';
-import { TiDelete } from 'react-icons/ti';
 interface Props {
   currentMeme: API_DATA | null | LOCAL_MEME;
   setCurrentMeme: Dispatch<SetStateAction<API_DATA | null | LOCAL_MEME>>;
   text: TEXT_TYPE;
   color: string;
+  textBoundary: TEXT_BOUNDARY | null;
 }
 
 const EditorImage = (
-  { currentMeme, text, color, setCurrentMeme }: Props,
+  { currentMeme, text, color, setCurrentMeme, textBoundary }: Props,
   ref: Ref<HTMLDivElement>
 ) => {
   const [isDragging, setIsDragging] = useState<boolean>(false);
-
   const handleEnter = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
@@ -50,11 +49,10 @@ const EditorImage = (
     const url = URL.createObjectURL(file);
     setCurrentMeme({ url: url });
   };
-
   return currentMeme ? (
     <ImgBox color={color} ref={ref}>
       <Img src={currentMeme!.url} alt='meme' draggable='false' />
-      <ImageText text={text} />
+      <ImageText text={text} textBoundary={textBoundary} />
     </ImgBox>
   ) : (
     <NoImage

--- a/components/editor/EditorMemeList.tsx
+++ b/components/editor/EditorMemeList.tsx
@@ -18,11 +18,9 @@ function EditorMemeList({ apiData, currentMeme, setCurrentMeme }: Props) {
   return (
     <MemeListContainer>
       <MemeContainer>
-        {currentMeme && (
-          <ClearButton onClick={handleClear}>
-            <FaRedoAlt />
-          </ClearButton>
-        )}
+        <ClearButton onClick={handleClear}>
+          <FaRedoAlt />
+        </ClearButton>
         {apiData.map((data) => (
           <Meme key={data.id} meme={data} setCurrentMeme={setCurrentMeme} />
         ))}

--- a/components/editor/ImageText.tsx
+++ b/components/editor/ImageText.tsx
@@ -1,12 +1,13 @@
 import React, { useRef, useState } from 'react';
 import styled from '@emotion/styled';
-import { TEXT_TYPE } from 'types';
+import { TEXT_BOUNDARY, TEXT_TYPE } from 'types';
 
 interface Props {
   text: TEXT_TYPE;
+  textBoundary: TEXT_BOUNDARY | null;
 }
 
-export const ImageText = ({ text }: Props) => {
+export const ImageText = ({ text, textBoundary }: Props) => {
   const [startX, setStartX] = useState(0);
   const [startY, setStartY] = useState(0);
   const [startTop, setStartTop] = useState(0);
@@ -37,6 +38,12 @@ export const ImageText = ({ text }: Props) => {
     e.stopPropagation();
     const toMoveTop = e.pageY - startY + startTop;
     const toMoveLeft = e.pageX - startX + startLeft;
+    const moveOptions =
+      toMoveTop + 10 <= 0 ||
+      toMoveTop + e.currentTarget.offsetHeight - 10 >= textBoundary!.bottom ||
+      toMoveLeft - e.currentTarget.offsetWidth / 2 + 10 <= 0 ||
+      toMoveLeft + e.currentTarget.offsetWidth / 2 - 10 >= textBoundary!.right;
+    if (moveOptions) return;
     textMover(toMoveTop, toMoveLeft, e);
   };
 
@@ -54,6 +61,21 @@ export const ImageText = ({ text }: Props) => {
     e.stopPropagation();
     const toMoveTop = e.changedTouches[0].pageY - startY + startTop;
     const toMoveLeft = e.changedTouches[0].pageX - startX + startLeft;
+    const moveOptions =
+      toMoveTop + 10 <= 0 ||
+      toMoveTop + e.currentTarget.offsetHeight - 10 >= textBoundary!.bottom ||
+      toMoveLeft - e.currentTarget.offsetWidth / 2 + 10 <= 0 ||
+      toMoveLeft + e.currentTarget.offsetWidth / 2 - 10 >= textBoundary!.right;
+    console.log(
+      'to Left:',
+      toMoveLeft,
+      'to Top:',
+      toMoveTop,
+      textBoundary,
+      'width:',
+      e.currentTarget.offsetWidth
+    );
+    if (moveOptions) return;
     textMover(toMoveTop, toMoveLeft, e);
   };
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -16,3 +16,8 @@ export type TEXT_TYPE = {
   middle: string;
   bottom: string;
 };
+
+export interface TEXT_BOUNDARY {
+  right: number;
+  bottom: number;
+}


### PR DESCRIPTION
## 구현 내용
- 밈 텍스트가 이미지 컨테이너 밖으로 이동될 수 있는 버그가 존재했습니다. 따라서, 해당 버그를 수정하기 위해 textBoundary값을 계산한 뒤, textMover 함수에 조건문을 추가하여 해당 이슈를 해결했습니다.